### PR TITLE
fixed font propagation, cleaned up dependencies

### DIFF
--- a/.changeset/crazy-donkeys-retire.md
+++ b/.changeset/crazy-donkeys-retire.md
@@ -1,0 +1,15 @@
+---
+"@sbc-connect/playwright-config": patch
+"@sbc-connect/eslint-config": patch
+"@sbc-connect/vitest-config": patch
+"@sbc-connect/nuxt-forms": patch
+"@sbc-connect/nuxt-auth": patch
+"@sbc-connect/nuxt-base": patch
+"@sbc-connect/nuxt-pay": patch
+"nuxt-forms-demo-app": patch
+"nuxt-auth-demo-app": patch
+"nuxt-base-demo-app": patch
+"nuxt-pay-demo-app": patch
+---
+
+Updated fonts propagation in base, cleaned up dependencies in layers

--- a/apps/demo/auth/package.json
+++ b/apps/demo/auth/package.json
@@ -26,17 +26,13 @@
     "@sbc-connect/nuxt-auth": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "catalog:",
     "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "happy-dom": "catalog:",
-    "otpauth": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vue/test-utils": "catalog:"
+    "@sbc-connect/eslint-config": "workspace:*",
+    "@sbc-connect/playwright-config": "workspace:*",
+    "@sbc-connect/vitest-config": "workspace:*",
+    "nuxt": "catalog:",
+    "typescript": "catalog:",
+    "vue": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/apps/demo/base/package.json
+++ b/apps/demo/base/package.json
@@ -26,17 +26,13 @@
     "@sbc-connect/nuxt-base": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "catalog:",
     "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "happy-dom": "catalog:",
-    "otpauth": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vue/test-utils": "catalog:"
+    "@sbc-connect/eslint-config": "workspace:*",
+    "@sbc-connect/playwright-config": "workspace:*",
+    "@sbc-connect/vitest-config": "workspace:*",
+    "nuxt": "catalog:",
+    "typescript": "catalog:",
+    "vue": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/apps/demo/forms/package.json
+++ b/apps/demo/forms/package.json
@@ -26,17 +26,13 @@
     "@sbc-connect/nuxt-forms": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "catalog:",
     "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "happy-dom": "catalog:",
-    "otpauth": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vue/test-utils": "catalog:"
+    "@sbc-connect/eslint-config": "workspace:*",
+    "@sbc-connect/playwright-config": "workspace:*",
+    "@sbc-connect/vitest-config": "workspace:*",
+    "nuxt": "catalog:",
+    "typescript": "catalog:",
+    "vue": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/apps/demo/pay/package.json
+++ b/apps/demo/pay/package.json
@@ -26,17 +26,13 @@
     "@sbc-connect/nuxt-pay": "workspace:*"
   },
   "devDependencies": {
-    "typescript": "catalog:",
     "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "happy-dom": "catalog:",
-    "otpauth": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vue/test-utils": "catalog:"
+    "@sbc-connect/eslint-config": "workspace:*",
+    "@sbc-connect/playwright-config": "workspace:*",
+    "@sbc-connect/vitest-config": "workspace:*",
+    "nuxt": "catalog:",
+    "typescript": "catalog:",
+    "vue": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   "license": "BSD-3-Clause",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "ci:publish": "changeset publish",
-    "lint": "eslint .",
-    "lint:fix": "eslint --fix ."
+    "ci:publish": "changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",

--- a/packages/configs/eslint-config/package.json
+++ b/packages/configs/eslint-config/package.json
@@ -4,5 +4,9 @@
   "version": "0.0.2",
   "repository": "github:bcgov/connect-nuxt",
   "main": "./eslint.config.ts",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@nuxt/eslint-config": "^1.6.0",
+    "eslint": "^9.31.0"
+  }
 }

--- a/packages/configs/playwright-config/package.json
+++ b/packages/configs/playwright-config/package.json
@@ -4,5 +4,9 @@
   "version": "0.0.2",
   "repository": "github:bcgov/connect-nuxt",
   "main": "./playwright.config.ts",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@axe-core/playwright": "^4.10.2",
+    "@playwright/test": "^1.52.0"
+  }
 }

--- a/packages/configs/playwright-config/package.json
+++ b/packages/configs/playwright-config/package.json
@@ -6,7 +6,7 @@
   "main": "./playwright.config.ts",
   "private": true,
   "dependencies": {
-    "@axe-core/playwright": "^4.10.2",
+    "@nuxt/test-utils": "catalog:",
     "@playwright/test": "^1.52.0"
   }
 }

--- a/packages/configs/vitest-config/package.json
+++ b/packages/configs/vitest-config/package.json
@@ -4,5 +4,12 @@
   "version": "0.0.2",
   "repository": "github:bcgov/connect-nuxt",
   "main": "./vitest.config.ts",
-  "private": true
+  "private": true,
+  "dependencies": {
+    "@nuxt/test-utils": "^3.19.1",
+    "@vitest/coverage-v8": "^3.2.3",
+    "dotenv": "^17.2.0",
+    "happy-dom": "^17.6.3",
+    "vitest": "^3.2.3"
+  }
 }

--- a/packages/configs/vitest-config/package.json
+++ b/packages/configs/vitest-config/package.json
@@ -7,8 +7,6 @@
   "private": true,
   "dependencies": {
     "@nuxt/test-utils": "catalog:",
-    "@vitest/coverage-v8": "^3.2.3",
-    "dotenv": "^17.2.0",
     "happy-dom": "^17.6.3",
     "vitest": "^3.2.3"
   }

--- a/packages/configs/vitest-config/package.json
+++ b/packages/configs/vitest-config/package.json
@@ -6,7 +6,7 @@
   "main": "./vitest.config.ts",
   "private": true,
   "dependencies": {
-    "@nuxt/test-utils": "^3.19.1",
+    "@nuxt/test-utils": "catalog:",
     "@vitest/coverage-v8": "^3.2.3",
     "dotenv": "^17.2.0",
     "happy-dom": "^17.6.3",

--- a/packages/layers/auth/package.json
+++ b/packages/layers/auth/package.json
@@ -20,27 +20,14 @@
     "typecheck": "npx nuxt typecheck"
   },
   "devDependencies": {
+    "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "@vue/test-utils": "catalog:",
-    "happy-dom": "catalog:",
     "nuxt": "catalog:",
-    "otpauth": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:",
     "vue": "catalog:",
-    "dotenv": "catalog:",
-    "vue-tsc": "catalog:",
-    "@nuxt/eslint-config": "catalog:",
-    "eslint": "catalog:"
+    "vue-tsc": "catalog:"
   },
   "dependencies": {
     "@sbc-connect/nuxt-base": "workspace:*"

--- a/packages/layers/auth/package.json
+++ b/packages/layers/auth/package.json
@@ -20,6 +20,7 @@
     "typecheck": "npx nuxt typecheck"
   },
   "devDependencies": {
+    "@axe-core/playwright": "catalog:",
     "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",

--- a/packages/layers/auth/package.json
+++ b/packages/layers/auth/package.json
@@ -25,6 +25,8 @@
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "dotenv": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vue": "catalog:",

--- a/packages/layers/base/modules/assets/index.ts
+++ b/packages/layers/base/modules/assets/index.ts
@@ -16,9 +16,9 @@ export default defineNuxtModule<ModuleOptions>({
     console.info('setting up assets module')
     const resolver = createResolver(import.meta.url)
 
+    _nuxt.options.css.push(resolver.resolve('./runtime/assets/core-tw.css'))
+    _nuxt.options.css.push(resolver.resolve('./runtime/assets/core-layout.css'))
     _nuxt.options.css.push(resolver.resolve('./runtime/assets/core-main.css'))
-    // _nuxt.options.css.push(resolver.resolve('./runtime/assets/core-tw.css'))
-    // _nuxt.options.css.push(resolver.resolve('./runtime/assets/core-layout.css'))
     await installModule('@nuxt/ui')
   }
 })

--- a/packages/layers/base/package.json
+++ b/packages/layers/base/package.json
@@ -20,29 +20,16 @@
     "typecheck": "npx nuxt typecheck"
   },
   "dependencies": {
-    "@nuxt/ui": "catalog:"
+    "@nuxt/ui": "^3.2.0"
   },
   "devDependencies": {
+    "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vue": "catalog:",
-    "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "happy-dom": "catalog:",
-    "otpauth": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vue/test-utils": "catalog:",
-    "dotenv": "catalog:",
-    "vue-tsc": "catalog:",
-    "@nuxt/eslint-config": "catalog:",
-    "eslint": "catalog:"
+    "vue-tsc": "catalog:"
   }
 }

--- a/packages/layers/base/package.json
+++ b/packages/layers/base/package.json
@@ -28,6 +28,8 @@
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "dotenv": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vue": "catalog:",

--- a/packages/layers/base/package.json
+++ b/packages/layers/base/package.json
@@ -23,6 +23,7 @@
     "@nuxt/ui": "^3.2.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "catalog:",
     "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",

--- a/packages/layers/forms/package.json
+++ b/packages/layers/forms/package.json
@@ -20,6 +20,7 @@
     "typecheck": "npx nuxt typecheck"
   },
   "devDependencies": {
+    "@axe-core/playwright": "catalog:",
     "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",

--- a/packages/layers/forms/package.json
+++ b/packages/layers/forms/package.json
@@ -20,27 +20,14 @@
     "typecheck": "npx nuxt typecheck"
   },
   "devDependencies": {
+    "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vue": "catalog:",
-    "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "happy-dom": "catalog:",
-    "otpauth": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vue/test-utils": "catalog:",
-    "dotenv": "catalog:",
-    "vue-tsc": "catalog:",
-    "@nuxt/eslint-config": "catalog:",
-    "eslint": "catalog:"
+    "vue-tsc": "catalog:"
   },
   "dependencies": {
     "@sbc-connect/nuxt-base": "workspace:*"

--- a/packages/layers/forms/package.json
+++ b/packages/layers/forms/package.json
@@ -25,6 +25,8 @@
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "dotenv": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vue": "catalog:",

--- a/packages/layers/pay/package.json
+++ b/packages/layers/pay/package.json
@@ -20,6 +20,7 @@
     "typecheck": "npx nuxt typecheck"
   },
   "devDependencies": {
+    "@axe-core/playwright": "catalog:",
     "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",

--- a/packages/layers/pay/package.json
+++ b/packages/layers/pay/package.json
@@ -20,27 +20,14 @@
     "typecheck": "npx nuxt typecheck"
   },
   "devDependencies": {
+    "@nuxtjs/i18n": "catalog:",
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vue": "catalog:",
-    "@nuxtjs/i18n": "catalog:",
-    "@playwright/test": "catalog:",
-    "@axe-core/playwright": "catalog:",
-    "@faker-js/faker": "catalog:",
-    "@nuxt/test-utils": "catalog:",
-    "vitest": "catalog:",
-    "@vitest/coverage-v8": "catalog:",
-    "happy-dom": "catalog:",
-    "otpauth": "catalog:",
-    "@testing-library/vue": "catalog:",
-    "@vue/test-utils": "catalog:",
-    "dotenv": "catalog:",
-    "vue-tsc": "catalog:",
-    "@nuxt/eslint-config": "catalog:",
-    "eslint": "catalog:"
+    "vue-tsc": "catalog:"
   },
   "dependencies": {
     "@sbc-connect/nuxt-auth": "workspace:*"

--- a/packages/layers/pay/package.json
+++ b/packages/layers/pay/package.json
@@ -25,6 +25,8 @@
     "@sbc-connect/eslint-config": "workspace:*",
     "@sbc-connect/playwright-config": "workspace:*",
     "@sbc-connect/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "dotenv": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vue": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,21 @@ settings:
 
 catalogs:
   default:
+    '@axe-core/playwright':
+      specifier: ^4.10.2
+      version: 4.10.2
+    '@nuxt/test-utils':
+      specifier: ^3.19.1
+      version: 3.19.2
     '@nuxtjs/i18n':
       specifier: ^9.5.5
       version: 9.5.6
+    '@vitest/coverage-v8':
+      specifier: ^3.2.3
+      version: 3.2.4
+    dotenv:
+      specifier: ^17.2.0
+      version: 17.2.0
     nuxt:
       specifier: 4.0.0
       version: 4.0.0
@@ -202,9 +214,9 @@ importers:
 
   packages/configs/playwright-config:
     dependencies:
-      '@axe-core/playwright':
-        specifier: ^4.10.2
-        version: 4.10.2(playwright-core@1.54.1)
+      '@nuxt/test-utils':
+        specifier: 'catalog:'
+        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@playwright/test':
         specifier: ^1.52.0
         version: 1.54.1
@@ -212,14 +224,8 @@ importers:
   packages/configs/vitest-config:
     dependencies:
       '@nuxt/test-utils':
-        specifier: ^3.19.1
+        specifier: 'catalog:'
         version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vitest/coverage-v8':
-        specifier: ^3.2.3
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      dotenv:
-        specifier: ^17.2.0
-        version: 17.2.0
       happy-dom:
         specifier: ^17.6.3
         version: 17.6.3
@@ -233,6 +239,9 @@ importers:
         specifier: workspace:*
         version: link:../base
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 'catalog:'
+        version: 4.10.2(playwright-core@1.54.1)
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
@@ -245,6 +254,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.2.0
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
@@ -264,6 +279,9 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0(@babel/parser@7.28.0)(@netlify/blobs@9.1.2)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.6.1)(jwt-decode@4.0.0)(magicast@0.3.5)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-router@4.5.1(vue@3.5.17(typescript@5.8.3)))(vue@3.5.17(typescript@5.8.3))(zod@3.25.76)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 'catalog:'
+        version: 4.10.2(playwright-core@1.54.1)
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
@@ -276,6 +294,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.2.0
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
@@ -295,6 +319,9 @@ importers:
         specifier: workspace:*
         version: link:../base
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 'catalog:'
+        version: 4.10.2(playwright-core@1.54.1)
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
@@ -307,6 +334,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.2.0
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
@@ -326,6 +359,9 @@ importers:
         specifier: workspace:*
         version: link:../auth
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 'catalog:'
+        version: 4.10.2(playwright-core@1.54.1)
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
@@ -338,6 +374,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.2.0
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,57 +6,15 @@ settings:
 
 catalogs:
   default:
-    '@axe-core/playwright':
-      specifier: ^4.10.2
-      version: 4.10.2
-    '@faker-js/faker':
-      specifier: ^9.8.0
-      version: 9.9.0
-    '@nuxt/eslint-config':
-      specifier: ^1.6.0
-      version: 1.6.0
-    '@nuxt/test-utils':
-      specifier: ^3.19.1
-      version: 3.19.2
-    '@nuxt/ui':
-      specifier: ^3.2.0
-      version: 3.2.0
     '@nuxtjs/i18n':
       specifier: ^9.5.5
       version: 9.5.6
-    '@playwright/test':
-      specifier: ^1.52.0
-      version: 1.54.1
-    '@testing-library/vue':
-      specifier: ^8.1.0
-      version: 8.1.0
-    '@vitest/coverage-v8':
-      specifier: ^3.2.3
-      version: 3.2.4
-    '@vue/test-utils':
-      specifier: ^2.4.6
-      version: 2.4.6
-    dotenv:
-      specifier: ^17.2.0
-      version: 17.2.0
-    eslint:
-      specifier: ^9.31.0
-      version: 9.31.0
-    happy-dom:
-      specifier: ^17.6.3
-      version: 17.6.3
     nuxt:
       specifier: 4.0.0
       version: 4.0.0
-    otpauth:
-      specifier: ^9.4.0
-      version: 9.4.0
     typescript:
       specifier: ^5.8.3
       version: 5.8.3
-    vitest:
-      specifier: ^3.2.3
-      version: 3.2.4
     vue:
       specifier: latest
       version: 3.5.17
@@ -96,42 +54,24 @@ importers:
         specifier: 'catalog:'
         version: 4.5.1(vue@3.5.17(typescript@5.8.3))
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
+      '@sbc-connect/eslint-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/eslint-config
+      '@sbc-connect/playwright-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/playwright-config
+      '@sbc-connect/vitest-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/vitest-config
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
+      vue-tsc:
         specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+        version: 3.0.3(typescript@5.8.3)
 
   apps/demo/base:
     dependencies:
@@ -148,42 +88,24 @@ importers:
         specifier: 'catalog:'
         version: 4.5.1(vue@3.5.17(typescript@5.8.3))
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
+      '@sbc-connect/eslint-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/eslint-config
+      '@sbc-connect/playwright-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/playwright-config
+      '@sbc-connect/vitest-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/vitest-config
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
+      vue-tsc:
         specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+        version: 3.0.3(typescript@5.8.3)
 
   apps/demo/forms:
     dependencies:
@@ -200,42 +122,24 @@ importers:
         specifier: 'catalog:'
         version: 4.5.1(vue@3.5.17(typescript@5.8.3))
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
+      '@sbc-connect/eslint-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/eslint-config
+      '@sbc-connect/playwright-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/playwright-config
+      '@sbc-connect/vitest-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/vitest-config
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
+      vue-tsc:
         specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+        version: 3.0.3(typescript@5.8.3)
 
   apps/demo/pay:
     dependencies:
@@ -252,42 +156,24 @@ importers:
         specifier: 'catalog:'
         version: 4.5.1(vue@3.5.17(typescript@5.8.3))
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
+      '@sbc-connect/eslint-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/eslint-config
+      '@sbc-connect/playwright-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/playwright-config
+      '@sbc-connect/vitest-config':
+        specifier: workspace:*
+        version: link:../../../packages/configs/vitest-config
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
+      vue-tsc:
         specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
+        version: 3.0.3(typescript@5.8.3)
 
   apps/stackblitz-template:
     dependencies:
@@ -305,11 +191,41 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
-  packages/configs/eslint-config: {}
+  packages/configs/eslint-config:
+    dependencies:
+      '@nuxt/eslint-config':
+        specifier: ^1.6.0
+        version: 1.6.0(@typescript-eslint/utils@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint:
+        specifier: ^9.31.0
+        version: 9.31.0(jiti@2.4.2)
 
-  packages/configs/playwright-config: {}
+  packages/configs/playwright-config:
+    dependencies:
+      '@axe-core/playwright':
+        specifier: ^4.10.2
+        version: 4.10.2(playwright-core@1.54.1)
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.54.1
 
-  packages/configs/vitest-config: {}
+  packages/configs/vitest-config:
+    dependencies:
+      '@nuxt/test-utils':
+        specifier: ^3.19.1
+        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+      '@vitest/coverage-v8':
+        specifier: ^3.2.3
+        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
+      dotenv:
+        specifier: ^17.2.0
+        version: 17.2.0
+      happy-dom:
+        specifier: ^17.6.3
+        version: 17.6.3
+      vitest:
+        specifier: ^3.2.3
+        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
 
   packages/layers/auth:
     dependencies:
@@ -317,24 +233,9 @@ importers:
         specifier: workspace:*
         version: link:../base
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/eslint-config':
-        specifier: 'catalog:'
-        version: 1.6.0(@typescript-eslint/utils@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
       '@sbc-connect/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
@@ -344,36 +245,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      dotenv:
-        specifier: 'catalog:'
-        version: 17.2.0
-      eslint:
-        specifier: 'catalog:'
-        version: 9.31.0(jiti@2.4.2)
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
-        specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
       vue:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
@@ -384,27 +261,12 @@ importers:
   packages/layers/base:
     dependencies:
       '@nuxt/ui':
-        specifier: 'catalog:'
+        specifier: ^3.2.0
         version: 3.2.0(@babel/parser@7.28.0)(@netlify/blobs@9.1.2)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.6.1)(jwt-decode@4.0.0)(magicast@0.3.5)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-router@4.5.1(vue@3.5.17(typescript@5.8.3)))(vue@3.5.17(typescript@5.8.3))(zod@3.25.76)
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/eslint-config':
-        specifier: 'catalog:'
-        version: 1.6.0(@typescript-eslint/utils@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
       '@sbc-connect/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
@@ -414,36 +276,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      dotenv:
-        specifier: 'catalog:'
-        version: 17.2.0
-      eslint:
-        specifier: 'catalog:'
-        version: 9.31.0(jiti@2.4.2)
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
-        specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
       vue:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
@@ -457,24 +295,9 @@ importers:
         specifier: workspace:*
         version: link:../base
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/eslint-config':
-        specifier: 'catalog:'
-        version: 1.6.0(@typescript-eslint/utils@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
       '@sbc-connect/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
@@ -484,36 +307,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      dotenv:
-        specifier: 'catalog:'
-        version: 17.2.0
-      eslint:
-        specifier: 'catalog:'
-        version: 9.31.0(jiti@2.4.2)
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
-        specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
       vue:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
@@ -527,24 +326,9 @@ importers:
         specifier: workspace:*
         version: link:../auth
     devDependencies:
-      '@axe-core/playwright':
-        specifier: 'catalog:'
-        version: 4.10.2(playwright-core@1.54.1)
-      '@faker-js/faker':
-        specifier: 'catalog:'
-        version: 9.9.0
-      '@nuxt/eslint-config':
-        specifier: 'catalog:'
-        version: 1.6.0(@typescript-eslint/utils@8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
-      '@nuxt/test-utils':
-        specifier: 'catalog:'
-        version: 3.19.2(@playwright/test@1.54.1)(@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3)))(@vue/test-utils@2.4.6)(happy-dom@17.6.3)(magicast@0.3.5)(playwright-core@1.54.1)(typescript@5.8.3)(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 9.5.6(@vue/compiler-dom@3.5.17)(eslint@9.31.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.45.1)(vue@3.5.17(typescript@5.8.3))
-      '@playwright/test':
-        specifier: 'catalog:'
-        version: 1.54.1
       '@sbc-connect/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
@@ -554,36 +338,12 @@ importers:
       '@sbc-connect/vitest-config':
         specifier: workspace:*
         version: link:../../configs/vitest-config
-      '@testing-library/vue':
-        specifier: 'catalog:'
-        version: 8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 3.2.4(vitest@3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))
-      '@vue/test-utils':
-        specifier: 'catalog:'
-        version: 2.4.6
-      dotenv:
-        specifier: 'catalog:'
-        version: 17.2.0
-      eslint:
-        specifier: 'catalog:'
-        version: 9.31.0(jiti@2.4.2)
-      happy-dom:
-        specifier: 'catalog:'
-        version: 17.6.3
       nuxt:
         specifier: 'catalog:'
         version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.5(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
-      otpauth:
-        specifier: 'catalog:'
-        version: 9.4.0
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
-      vitest:
-        specifier: 'catalog:'
-        version: 3.2.4(happy-dom@17.6.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
       vue:
         specifier: 'catalog:'
         version: 3.5.17(typescript@5.8.3)
@@ -1203,10 +963,6 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@faker-js/faker@9.9.0':
-    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
-    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
-
   '@fastify/busboy@3.1.1':
     resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
 
@@ -1443,10 +1199,6 @@ packages:
     resolution: {integrity: sha512-zAr+8Tg80y/sUbhdUkZsq4Uy1IMzkSB6H/sKRMrDQ2NJx4uPgf5X5jMdg9g2FljNcxzpfJwc1Gg4OXQrjD0Z4A==}
     engines: {node: '>=18.14.0'}
     hasBin: true
-
-  '@noble/hashes@1.7.1':
-    resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
-    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5108,9 +4860,6 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
-  otpauth@9.4.0:
-    resolution: {integrity: sha512-fHIfzIG5RqCkK9cmV8WU+dPQr9/ebR5QOwGZn2JAr1RQF+lmAuLL2YdtdqvmBjNmgJlYk3KZ4a0XokaEhg1Jsw==}
-
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -7338,8 +7087,6 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
-  '@faker-js/faker@9.9.0': {}
-
   '@fastify/busboy@3.1.1': {}
 
   '@floating-ui/core@1.7.2':
@@ -7681,8 +7428,6 @@ snapshots:
       - encoding
       - rollup
       - supports-color
-
-  '@noble/hashes@1.7.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8303,7 +8048,8 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@one-ini/wasm@0.1.1': {}
+  '@one-ini/wasm@0.1.1':
+    optional: true
 
   '@oxc-minify/binding-android-arm64@0.77.2':
     optional: true
@@ -8846,6 +8592,7 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
       pretty-format: 27.5.1
+    optional: true
 
   '@testing-library/vue@8.1.0(@vue/compiler-sfc@3.5.17)(vue@3.5.17(typescript@5.8.3))':
     dependencies:
@@ -8855,13 +8602,15 @@ snapshots:
       vue: 3.5.17(typescript@5.8.3)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.17
+    optional: true
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@types/aria-query@5.0.4': {}
+  '@types/aria-query@5.0.4':
+    optional: true
 
   '@types/chai@5.2.2':
     dependencies:
@@ -9315,6 +9064,7 @@ snapshots:
     dependencies:
       js-beautify: 1.15.4
       vue-component-type-helpers: 2.2.12
+    optional: true
 
   '@vueuse/core@10.11.1(vue@3.5.17(typescript@5.8.3))':
     dependencies:
@@ -9402,7 +9152,8 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
-  abbrev@2.0.0: {}
+  abbrev@2.0.0:
+    optional: true
 
   abbrev@3.0.1: {}
 
@@ -9441,7 +9192,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@5.2.0: {}
+  ansi-styles@5.2.0:
+    optional: true
 
   ansi-styles@6.2.1: {}
 
@@ -9487,11 +9239,13 @@ snapshots:
   aria-query@5.1.3:
     dependencies:
       deep-equal: 2.2.3
+    optional: true
 
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
+    optional: true
 
   array-union@2.1.0: {}
 
@@ -9542,6 +9296,7 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+    optional: true
 
   axe-core@4.10.3: {}
 
@@ -9645,6 +9400,7 @@ snapshots:
       es-define-property: 1.0.1
       get-intrinsic: 1.3.0
       set-function-length: 1.2.2
+    optional: true
 
   call-bound@1.0.4:
     dependencies:
@@ -9794,6 +9550,7 @@ snapshots:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
+    optional: true
 
   consola@3.4.2: {}
 
@@ -9965,6 +9722,7 @@ snapshots:
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
       which-typed-array: 1.1.19
+    optional: true
 
   deep-is@0.1.4: {}
 
@@ -9982,6 +9740,7 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+    optional: true
 
   define-lazy-prop@2.0.0: {}
 
@@ -9992,6 +9751,7 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+    optional: true
 
   defu@6.1.4: {}
 
@@ -10075,7 +9835,8 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dom-accessibility-api@0.5.16: {}
+  dom-accessibility-api@0.5.16:
+    optional: true
 
   dom-serializer@2.0.0:
     dependencies:
@@ -10121,6 +9882,7 @@ snapshots:
       commander: 10.0.1
       minimatch: 9.0.1
       semver: 7.7.2
+    optional: true
 
   ee-first@1.1.1: {}
 
@@ -10208,6 +9970,7 @@ snapshots:
       is-string: 1.1.1
       isarray: 2.0.5
       stop-iteration-iterator: 1.1.0
+    optional: true
 
   es-module-lexer@1.7.0: {}
 
@@ -10632,6 +10395,7 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+    optional: true
 
   foreground-child@3.3.1:
     dependencies:
@@ -10666,7 +10430,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  functions-have-names@1.2.3: {}
+  functions-have-names@1.2.3:
+    optional: true
 
   fuse.js@7.1.0: {}
 
@@ -10803,19 +10568,22 @@ snapshots:
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
 
-  has-bigints@1.1.0: {}
+  has-bigints@1.1.0:
+    optional: true
 
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
+    optional: true
 
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
+    optional: true
 
   hasown@2.0.2:
     dependencies:
@@ -10887,7 +10655,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8: {}
+  ini@1.3.8:
+    optional: true
 
   ini@4.1.1: {}
 
@@ -10896,6 +10665,7 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+    optional: true
 
   ioredis@5.6.1:
     dependencies:
@@ -10917,18 +10687,21 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+    optional: true
 
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+    optional: true
 
   is-arrayish@0.3.2: {}
 
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.1.0
+    optional: true
 
   is-binary-path@2.1.0:
     dependencies:
@@ -10938,6 +10711,7 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+    optional: true
 
   is-builtin-module@3.2.1:
     dependencies:
@@ -10947,7 +10721,8 @@ snapshots:
     dependencies:
       builtin-modules: 5.0.0
 
-  is-callable@1.2.7: {}
+  is-callable@1.2.7:
+    optional: true
 
   is-core-module@2.16.1:
     dependencies:
@@ -10957,6 +10732,7 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+    optional: true
 
   is-docker@2.2.1: {}
 
@@ -10979,7 +10755,8 @@ snapshots:
       global-directory: 4.0.1
       is-path-inside: 4.0.0
 
-  is-map@2.0.3: {}
+  is-map@2.0.3:
+    optional: true
 
   is-module@1.0.0: {}
 
@@ -10987,6 +10764,7 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+    optional: true
 
   is-number@7.0.0: {}
 
@@ -11004,12 +10782,15 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+    optional: true
 
-  is-set@2.0.3: {}
+  is-set@2.0.3:
+    optional: true
 
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+    optional: true
 
   is-ssh@1.4.1:
     dependencies:
@@ -11025,6 +10806,7 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+    optional: true
 
   is-subdir@1.2.0:
     dependencies:
@@ -11035,17 +10817,20 @@ snapshots:
       call-bound: 1.0.4
       has-symbols: 1.1.0
       safe-regex-test: 1.1.0
+    optional: true
 
   is-url-superb@4.0.0: {}
 
   is-url@1.2.4: {}
 
-  is-weakmap@2.0.2: {}
+  is-weakmap@2.0.2:
+    optional: true
 
   is-weakset@2.0.4:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+    optional: true
 
   is-what@4.1.16: {}
 
@@ -11065,7 +10850,8 @@ snapshots:
 
   isarray@1.0.0: {}
 
-  isarray@2.0.5: {}
+  isarray@2.0.5:
+    optional: true
 
   isbinaryfile@5.0.4: {}
 
@@ -11109,8 +10895,10 @@ snapshots:
       glob: 10.4.5
       js-cookie: 3.0.5
       nopt: 7.2.1
+    optional: true
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.5:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -11313,7 +11101,8 @@ snapshots:
 
   luxon@3.7.1: {}
 
-  lz-string@1.5.0: {}
+  lz-string@1.5.0:
+    optional: true
 
   magic-regexp@0.10.0:
     dependencies:
@@ -11397,6 +11186,7 @@ snapshots:
   minimatch@9.0.1:
     dependencies:
       brace-expansion: 2.0.2
+    optional: true
 
   minimatch@9.0.5:
     dependencies:
@@ -11586,6 +11376,7 @@ snapshots:
   nopt@7.2.1:
     dependencies:
       abbrev: 2.0.0
+    optional: true
 
   nopt@8.1.0:
     dependencies:
@@ -11754,8 +11545,10 @@ snapshots:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
+    optional: true
 
-  object-keys@1.1.1: {}
+  object-keys@1.1.1:
+    optional: true
 
   object.assign@4.1.7:
     dependencies:
@@ -11765,6 +11558,7 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+    optional: true
 
   ofetch@1.4.1:
     dependencies:
@@ -11815,10 +11609,6 @@ snapshots:
       word-wrap: 1.2.5
 
   os-tmpdir@1.0.2: {}
-
-  otpauth@9.4.0:
-    dependencies:
-      '@noble/hashes': 1.7.1
 
   outdent@0.5.0: {}
 
@@ -12057,7 +11847,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  possible-typed-array-names@1.1.0: {}
+  possible-typed-array-names@1.1.0:
+    optional: true
 
   postcss-calc@10.1.1(postcss@8.5.6):
     dependencies:
@@ -12264,6 +12055,7 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+    optional: true
 
   process-nextick-args@2.0.1: {}
 
@@ -12274,7 +12066,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
-  proto-list@1.2.4: {}
+  proto-list@1.2.4:
+    optional: true
 
   protocols@2.0.2: {}
 
@@ -12325,7 +12118,8 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.5
 
-  react-is@17.0.2: {}
+  react-is@17.0.2:
+    optional: true
 
   read-package-up@11.0.0:
     dependencies:
@@ -12407,6 +12201,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+    optional: true
 
   regjsparser@0.12.0:
     dependencies:
@@ -12509,6 +12304,7 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+    optional: true
 
   safe-stable-stringify@2.5.0: {}
 
@@ -12569,6 +12365,7 @@ snapshots:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
+    optional: true
 
   set-function-name@2.0.2:
     dependencies:
@@ -12576,6 +12373,7 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
+    optional: true
 
   setprototypeof@1.2.0: {}
 
@@ -12704,6 +12502,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+    optional: true
 
   streamx@2.22.1:
     dependencies:
@@ -13403,6 +13202,7 @@ snapshots:
       is-number-object: 1.1.1
       is-string: 1.1.1
       is-symbol: 1.1.1
+    optional: true
 
   which-collection@1.0.2:
     dependencies:
@@ -13410,6 +13210,7 @@ snapshots:
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
+    optional: true
 
   which-typed-array@1.1.19:
     dependencies:
@@ -13420,6 +13221,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+    optional: true
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,9 +3,11 @@ packages:
   - 'packages/**'
 
 catalog:
+  '@axe-core/playwright': ^4.10.2
+  '@nuxtjs/i18n': ^9.5.5
+  '@nuxt/test-utils': ^3.19.1
   nuxt: 4.0.0
   typescript: ^5.8.3
   vue: "latest"
   vue-router: "^4.5.1"
-  '@nuxtjs/i18n': ^9.5.5
   vue-tsc: ^3.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,18 +8,4 @@ catalog:
   vue: "latest"
   vue-router: "^4.5.1"
   '@nuxtjs/i18n': ^9.5.5
-  '@playwright/test': ^1.52.0
-  '@axe-core/playwright': ^4.10.2
-  '@faker-js/faker': ^9.8.0
-  '@nuxt/test-utils': ^3.19.1
-  vitest: ^3.2.3
-  '@vitest/coverage-v8': ^3.2.3
-  happy-dom: ^17.6.3
-  otpauth: ^9.4.0
-  '@testing-library/vue': ^8.1.0
-  '@vue/test-utils': ^2.4.6
-  '@nuxt/ui': ^3.2.0
-  dotenv: ^17.2.0
   vue-tsc: ^3.0.2
-  eslint: ^9.31.0
-  '@nuxt/eslint-config': ^1.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ catalog:
   '@axe-core/playwright': ^4.10.2
   '@nuxtjs/i18n': ^9.5.5
   '@nuxt/test-utils': ^3.19.1
+  '@vitest/coverage-v8': ^3.2.3
+  dotenv: ^17.2.0
   nuxt: 4.0.0
   typescript: ^5.8.3
   vue: "latest"


### PR DESCRIPTION
- alias to font was broken without adding the font css file in the module init
- moved deps into config packages where applicable
- removed deps from catalog where they are only referenced in one place
- removed deps that I am unsure will be needed 
  - you should double check these or we can add them back when needed:
    - @vue/test-utils
    - @testing-library/vue
    - @faker-js/faker
    - otpauth