### PR TITLE
Nuxt Layers: Fix account label css

### DIFF
--- a/packages/layers/auth/app/components/Connect/Header/AccountLabel.vue
+++ b/packages/layers/auth/app/components/Connect/Header/AccountLabel.vue
@@ -26,7 +26,7 @@ defineProps({
       </span>
       <span
         class="line-clamp-1 overflow-hidden text-ellipsis text-xs opacity-75"
-        :class="{ 'text-line': theme === 'header', 'text-neutral': theme === 'dropdown' }"
+        :class="{ 'text-line-muted': theme === 'header', 'text-neutral': theme === 'dropdown' }"
       >
         {{ accountName }}
       </span>


### PR DESCRIPTION
issue: bcgov/entity#29335

Fix the incorrect CSS property set on the account label text.