### PR TITLE
25807 address display update

### DIFF
--- a/.changeset/wild-trams-sell.md
+++ b/.changeset/wild-trams-sell.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-base": patch
+---
+
+Address display component update

--- a/packages/layers/base/.playground/app/pages/examples/components/ConnectAddressDisplay.vue
+++ b/packages/layers/base/.playground/app/pages/examples/components/ConnectAddressDisplay.vue
@@ -14,6 +14,8 @@ definePageMeta({
       <ul>
         <li>`address` - ConnectAddress - required</li>
         <li>`omitCountry` - boolean - optional</li>
+        <li>`separateCity` - boolean - optional</li>
+        <li>`textDecor` - boolean - optional</li>
       </ul>
     </ConnectPageSection>
 
@@ -27,9 +29,6 @@ definePageMeta({
           postalCode: 'V1X 1X1',
           country: 'CA',
           locationDescription: 'Some extra location info',
-          // streetName?: string
-          // streetNumber?: string
-          // unitNumber?: string
         }"
       />
     </ConnectPageSection>
@@ -44,11 +43,38 @@ definePageMeta({
           postalCode: 'V1X 1X1',
           country: 'CA',
           locationDescription: 'Some extra location info',
-          // streetName?: string
-          // streetNumber?: string
-          // unitNumber?: string
         }"
         :omit-country="true"
+      />
+    </ConnectPageSection>
+
+    <ConnectPageSection :heading="{ label: 'Separate City' }" ui-body="p-4 space-y-4">
+      <ConnectAddressDisplay
+        :address="{
+          street: '123 Street Ave',
+          streetAdditional: 'Line 2',
+          city: 'Townsville',
+          region: 'XY',
+          postalCode: 'V1X 1X1',
+          country: 'CA',
+          locationDescription: 'Some extra location info',
+        }"
+        :separate-city="true"
+      />
+    </ConnectPageSection>
+
+    <ConnectPageSection :heading="{ label: 'Text Decor' }" ui-body="p-4 space-y-4">
+      <ConnectAddressDisplay
+        :address="{
+          street: '123 Street Ave',
+          streetAdditional: 'Line 2',
+          city: 'Townsville',
+          region: 'XY',
+          postalCode: 'V1X 1X1',
+          country: 'Canada',
+          locationDescription: 'Some extra location info',
+        }"
+        :text-decor="true"
       />
     </ConnectPageSection>
 

--- a/packages/layers/base/app/components/Connect/Address/Display.vue
+++ b/packages/layers/base/app/components/Connect/Address/Display.vue
@@ -2,6 +2,8 @@
 const props = defineProps<{
   address: Partial<ConnectAddress>
   omitCountry?: boolean
+  separateCity?: boolean
+  textDecor?: boolean
 }>()
 
 const getAddressDisplayParts = (
@@ -37,9 +39,12 @@ const getAddressDisplayParts = (
   }
 
   const getCountry = () => {
-    return address.country && !omitCountry ? (regionNamesInEnglish.of(address.country) || address.country) : ''
+    try {
+      return address.country && !omitCountry ? (regionNamesInEnglish.of(address.country) || address.country) : ''
+    } catch {
+      return address.country || ''
+    }
   }
-
   return [
     getLine1(),
     getLine2(),
@@ -49,7 +54,7 @@ const getAddressDisplayParts = (
   ].filter(val => !!val && val !== ',')
 }
 
-const addressDisplay = getAddressDisplayParts(props.address, false, true, props.omitCountry)
+const addressDisplay = getAddressDisplayParts(props.address, props.separateCity, props.textDecor, props.omitCountry)
 </script>
 
 <template>


### PR DESCRIPTION
Minor tweaks to the address display component
- no longer errs on invalid country code (defaults to value passed in)
- added separateCity / textDecor props

<img width="442" height="260" alt="Screenshot 2025-08-29 at 3 55 23 PM" src="https://github.com/user-attachments/assets/4527a108-09c6-48b3-8078-32586b1b9121" />
<img width="379" height="543" alt="Screenshot 2025-08-29 at 3 55 31 PM" src="https://github.com/user-attachments/assets/e06b12cb-e094-4e6b-bec7-9b50531a69d6" />
