### PR TITLE
UI standardization - form wrapper padding and error border updates

### DIFF
--- a/.changeset/bold-cobras-spend.md
+++ b/.changeset/bold-cobras-spend.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-forms": patch
+---
+
+Apply new padding and error classes to form wrapper elements, add optional prop to apply aria-hidden to formfieldwrapper details content.

--- a/.changeset/dark-pumas-walk.md
+++ b/.changeset/dark-pumas-walk.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-base": patch
+---
+
+Custom CSS classes for x and xy default padding and left error border for container elements.

--- a/packages/layers/base/app/assets/css/connect-base-tw.css
+++ b/packages/layers/base/app/assets/css/connect-base-tw.css
@@ -90,9 +90,10 @@
   --marker-upper-alpha: upper-alpha;
 
   /* box shadow */
-  --shadow-input: inset 0 -1px 0 0px var(--ui-neutral);
-  --shadow-input-focus: inset 0 -2px 0 0px var(--ui-primary);
-  --shadow-input-error: inset 0 -2px 0 0px var(--ui-error);
+  /* bottom neutral/focused/error border for input elements */
+  --shadow-input: inset 0 -1px 0 0 var(--ui-neutral);
+  --shadow-input-focus: inset 0 -2px 0 0 var(--ui-primary);
+  --shadow-input-error: inset 0 -2px 0 0 var(--ui-error);
 
   /* GRAY */
   --color-gray-50: #f8f9fa;
@@ -273,5 +274,30 @@ body {
   
   .floating-label-textarea {
     @apply pointer-events-none absolute left-0 top-1 text-neutral text-xs font-medium px-2.5 transition-all duration-200 peer-focus:top-1 peer-focus:text-xs peer-placeholder-shown:text-sm peer-placeholder-shown:top-2.5 peer-focus:translate-none peer-focus:text-primary peer-aria-invalid:text-error;
+  }
+
+  /* Standard container padding */
+  .padding-x-default {
+    @apply px-4 sm:px-7.5
+  }
+  
+  .padding-xy-default {
+    @apply py-6 px-4 sm:py-10 sm:px-7.5
+  }
+
+  /* left error border for section elements */
+  /* Psuedo element required to be visible so slot content does not cover it */
+  .shadow-section-error {
+    position: relative;
+  }
+
+  .shadow-section-error::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background-color: var(--ui-error);
+    pointer-events: none;
+    z-index: 1;
   }
 }

--- a/packages/layers/forms/.playground/app/pages/examples/components/ConnectFieldset/index.vue
+++ b/packages/layers/forms/.playground/app/pages/examples/components/ConnectFieldset/index.vue
@@ -205,7 +205,7 @@ definePageMeta({
       ui-body="space-y-4"
     >
       <ConnectFieldset label="Fieldset Label" body-variant="card">
-        <div class="border border-black p-10">
+        <div class="p-10">
           Slot Content
         </div>
       </ConnectFieldset>
@@ -221,7 +221,7 @@ definePageMeta({
         body-variant="card"
         orientation="vertical"
       >
-        <div class="border border-black p-10">
+        <div class="p-10">
           Slot Content
         </div>
       </ConnectFieldset>
@@ -240,7 +240,7 @@ definePageMeta({
         description="Some fancy description text"
         :show-error-msg="true"
       >
-        <div class="border border-black p-10">
+        <div class="p-10">
           Slot Content
         </div>
       </ConnectFieldset>

--- a/packages/layers/forms/.playground/app/pages/examples/components/ConnectFormFieldWrapper/index.vue
+++ b/packages/layers/forms/.playground/app/pages/examples/components/ConnectFormFieldWrapper/index.vue
@@ -28,6 +28,7 @@ definePageMeta({
     <ConnectPageSection :heading="{ label: 'Props' }" ui-body="sm:p-6 space-y-4">
       <ul>
         <li>`label` - string - required</li>
+        <li>`detailsAriaHidden` - boolean - default: false</li>
         <li>`error` - FormError | boolean - optional</li>
         <li>`showErrorMsg` - boolean - optional</li>
         <li>`orientation` - 'vertical' | 'horizontal' - default: horizontal</li>
@@ -37,6 +38,14 @@ definePageMeta({
 
     <ConnectPageSection :heading="{ label: 'ConnectFormFieldWrapper (default)' }" ui-body="space-y-4">
       <ConnectFormFieldWrapper label="Wrapper Label">
+        <div class="border border-black p-10">
+          Slot Content
+        </div>
+      </ConnectFormFieldWrapper>
+    </ConnectPageSection>
+
+    <ConnectPageSection :heading="{ label: 'ConnectFormFieldWrapper (detailsAriaHidden = true)' }" ui-body="space-y-4">
+      <ConnectFormFieldWrapper label="Wrapper Label" :details-aria-hidden="true">
         <div class="border border-black p-10">
           Slot Content
         </div>

--- a/packages/layers/forms/app/components/Connect/Fieldset.vue
+++ b/packages/layers/forms/app/components/Connect/Fieldset.vue
@@ -21,19 +21,19 @@ const legendId = id + '-legend'
 const descriptionId = id + '-description'
 
 const bodyClassMap = computed<Record<FieldsetBodyVariant, string>>(() => {
-  const cardError = error ? 'border-error border-l-3' : 'border-transparent border-l-3'
+  const cardError = error ? 'shadow-section-error' : ''
   return {
     none: '',
-    card: 'bg-white rounded shadow-xs ' + cardError
+    card: 'bg-white rounded shadow-xs overflow-hidden ' + cardError
   }
 })
 
 const bodyClass = computed(() => bodyClassMap.value[bodyVariant])
 
 const padding = paddingClass === 'x-default'
-  ? 'px-4 sm:px-8'
+  ? 'padding-x-default'
   : paddingClass === 'xy-default'
-    ? 'py-6 px-4 sm:py-10 sm:px-8'
+    ? 'padding-xy-default'
     : paddingClass
 </script>
 
@@ -44,7 +44,7 @@ const padding = paddingClass === 'x-default'
         'flex gap-4 sm:gap-6',
         bodyVariant === 'none' ? padding : '',
         orientation === 'horizontal' ? 'flex-col sm:flex-row' : 'flex-col',
-        (error && bodyVariant === 'none') ? 'border-error border-l-3' : 'border-transparent border-l-3',
+        (error && bodyVariant === 'none') ? 'shadow-section-error' : '',
       ]"
     >
       <div

--- a/packages/layers/forms/app/components/Connect/Form/FieldWrapper.vue
+++ b/packages/layers/forms/app/components/Connect/Form/FieldWrapper.vue
@@ -3,19 +3,21 @@ import type { FormError } from '@nuxt/ui'
 
 const {
   orientation = 'horizontal',
-  paddingClass = 'x-default'
+  paddingClass = 'x-default',
+  detailsAriaHidden = false
 } = defineProps<{
   label: string
   error?: FormError | boolean
+  detailsAriaHidden?: boolean
   showErrorMsg?: boolean
   orientation?: 'vertical' | 'horizontal'
   paddingClass?: 'x-default' | 'xy-default' | string
 }>()
 
 const padding = paddingClass === 'x-default'
-  ? 'px-4 sm:px-8'
+  ? 'padding-x-default'
   : paddingClass === 'xy-default'
-    ? 'py-6 px-4 sm:py-10 sm:px-8'
+    ? 'padding-xy-default'
     : paddingClass
 </script>
 
@@ -25,11 +27,11 @@ const padding = paddingClass === 'x-default'
       'flex gap-4 sm:gap-6',
       padding,
       orientation === 'horizontal' ? 'flex-col sm:flex-row' : 'flex-col',
-      error ? 'border-error border-l-3' : 'border-transparent border-l-3',
+      error ? 'shadow-section-error' : '',
     ]"
   >
     <span
-      aria-hidden="true"
+      :aria-hidden="detailsAriaHidden"
       class="text-base text-neutral-highlighted font-bold"
       :class="{ 'w-full sm:basis-1/4': orientation === 'horizontal' }"
     >


### PR DESCRIPTION
*Issue #:* bcgov/entity#33288 bcgov/entity#33225

*Description of changes:*
- add custom classes for:
  - default x padding
  - default xy padding
  - left error border for section elements
- apply to form container elements
- do not aria hide formfieldwrapper details by default and add prop to configure

*Screenshots (if applicable):*

---

<details>
<summary><b>⚠️ First time contributing to bcgov/connect-nuxt? Click here!</b></summary>

#### Contributor Checklist

- **Onboarding**
  - [ ] I have read the project's main **README**.
  - [ ] I have read and agree to the **Code of Conduct**.
  - [ ] I have read the **CONTRIBUTING guide** for development standards and workflow.
- **Code & Context**
  - [ ] I have read the **package-specific README** for the package I am modifying.
  - [ ] **Code Style:** My code follows the project's established style guidelines.
  - [ ] **i18n:** All text is managed via language files; no hardcoded strings.
  - [ ] **Responsive:** I have verified this change works on multiple screen sizes.
  - [ ] **Testing:** I have added or updated unit or E2E tests to cover my changes.
  - [ ] **Local Build:** I have successfully built the project locally and confirmed no new errors.
  - [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).
- **Documentation & Examples**
  - [ ] I have updated the relevant documentation (or created new documentation).
  - [ ] I have updated the relevant examples (or created new examples) in the `.playground` directory for new components, composables, pages, etc.
</details>

---

#### ⚠️ Reviewer Checklist
*This section is to be completed by the reviewer.*

- [ ] **Requirements:** Code matches the issue requirements.
- [ ] **Security:** No secrets/keys committed.
- [ ] **Standards:** Follows the code style and standards defined in the CONTRIBUTING file.
- [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BSD-3-Clause license.