### PR TITLE
33512 "No Fee" label stays on a single line

### DIFF
--- a/.changeset/sour-ghosts-sneeze.md
+++ b/.changeset/sour-ghosts-sneeze.md
@@ -2,4 +2,4 @@
 "@sbc-connect/nuxt-pay": minor
 ---
 
-no wrap no fee
+Ensure the "No Fee" label stays on a single line by applying a no-wrap style

--- a/.changeset/sour-ghosts-sneeze.md
+++ b/.changeset/sour-ghosts-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-pay": minor
+---
+
+no wrap no fee

--- a/packages/layers/pay/.playground/app/pages/examples/components/ConnectFeeWidget/multipleFees.vue
+++ b/packages/layers/pay/.playground/app/pages/examples/components/ConnectFeeWidget/multipleFees.vue
@@ -12,6 +12,7 @@ const exampleFeeCode1 = 'BSRCH'
 const exampleFeeCode2 = 'CGOOD'
 const exampleFeeCode3 = 'NM620'
 const exampleFeeCode4 = 'BCINC'
+const exampleFeeCode5 = 'NOCOI'
 
 const { t } = useI18n()
 await feeStore.initFees(
@@ -19,7 +20,8 @@ await feeStore.initFees(
     { code: exampleFeeCode1, entityType: 'BUS', label: t('connect.label.exampleFee') + '1' },
     { code: exampleFeeCode2, entityType: 'BUS', label: t('connect.label.exampleFee') + '2' },
     { code: exampleFeeCode3, entityType: 'NRO', label: t('connect.label.exampleFee') + '3' },
-    { code: exampleFeeCode4, entityType: 'BC', label: t('connect.label.exampleFee') + '4' }
+    { code: exampleFeeCode4, entityType: 'BC', label: t('connect.label.exampleFee') + '4' },
+    { code: exampleFeeCode5, entityType: 'BC', label: t('connect.label.longExampleNoFee') }
   ],
   { label: t('connect.label.examplePlaceholder'), matchServiceFeeToCode: exampleFeeCode1 }
 )
@@ -27,6 +29,7 @@ feeStore.addReplaceFee(exampleFeeCode1)
 feeStore.addReplaceFee(exampleFeeCode2)
 feeStore.addReplaceFee(exampleFeeCode3)
 feeStore.addReplaceFee(exampleFeeCode4)
+feeStore.addReplaceFee(exampleFeeCode5)
 </script>
 
 <template>

--- a/packages/layers/pay/.playground/i18n/locales/en-CA.ts
+++ b/packages/layers/pay/.playground/i18n/locales/en-CA.ts
@@ -2,6 +2,7 @@ export default {
   connect: {
     label: {
       exampleFee: 'Example Fee',
+      longExampleNoFee: 'Multi Line example to show No Fee in one line',
       exampleFeePriority: 'Priority Option Fee',
       exampleFeeFutureEffective: 'Future Effective Option Fee',
       examplePlaceholder: 'Example Placeholder',

--- a/packages/layers/pay/app/components/Connect/Fee/Widget.vue
+++ b/packages/layers/pay/app/components/Connect/Fee/Widget.vue
@@ -117,7 +117,7 @@ const getItemFee = (feeItem: ConnectFeeItem) => {
                 x {{ feeItem.quantity }} {{ feeItem.quantityDesc }}
               </p>
             </div>
-            <p class="text-highlighted">
+            <p class="text-highlighted whitespace-nowrap">
               {{ getItemFee(feeItem) }}
             </p>
           </div>


### PR DESCRIPTION
*Issue #:* bcgov/entity#33512

*Description of changes:*
<img width="667" height="606" alt="image" src="https://github.com/user-attachments/assets/016125fa-b625-494e-92ef-6c2130d79ccf" />

*Screenshots (if applicable):*

---

<details>
<summary><b>⚠️ First time contributing to bcgov/connect-nuxt? Click here!</b></summary>

#### Contributor Checklist

- **Onboarding**
  - [ ] I have read the project's main **README**.
  - [ ] I have read and agree to the **Code of Conduct**.
  - [ ] I have read the **CONTRIBUTING guide** for development standards and workflow.
- **Code & Context**
  - [ ] I have read the **package-specific README** for the package I am modifying.
  - [ ] **Code Style:** My code follows the project's established style guidelines.
  - [ ] **i18n:** All text is managed via language files; no hardcoded strings.
  - [ ] **Responsive:** I have verified this change works on multiple screen sizes.
  - [ ] **Testing:** I have added or updated unit or E2E tests to cover my changes.
  - [ ] **Local Build:** I have successfully built the project locally and confirmed no new errors.
  - [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).
- **Documentation & Examples**
  - [ ] I have updated the relevant documentation (or created new documentation).
  - [ ] I have updated the relevant examples (or created new examples) in the `.playground` directory for new components, composables, pages, etc.
</details>

---

#### ⚠️ Reviewer Checklist
*This section is to be completed by the reviewer.*

- [ ] **Requirements:** Code matches the issue requirements.
- [ ] **Security:** No secrets/keys committed.
- [ ] **Standards:** Follows the code style and standards defined in the CONTRIBUTING file.
- [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BSD-3-Clause license.