### PR TITLE
33691 - Force token refresh after user is created in auth for new users

### DIFF
--- a/.changeset/tall-sites-cross.md
+++ b/.changeset/tall-sites-cross.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-auth": minor
+---
+
+Force token refresh after user is created in auth for new users (0 accounts) only.

--- a/packages/layers/auth/app/plugins/connect-account-bootstrap.client.ts
+++ b/packages/layers/auth/app/plugins/connect-account-bootstrap.client.ts
@@ -16,7 +16,7 @@ export default defineNuxtPlugin({
 
       // Force token refresh to return updated roles
       // Required only for new users
-      if (store.userAccounts.length > 0) {
+      if (store.userAccounts.length === 0) {
         await getToken(true)
       }
     }

--- a/packages/layers/auth/app/plugins/connect-account-bootstrap.client.ts
+++ b/packages/layers/auth/app/plugins/connect-account-bootstrap.client.ts
@@ -4,15 +4,21 @@ export default defineNuxtPlugin({
   dependsOn: ['connect-auth', 'auth-api'],
   parallel: true,
   async setup(nuxtApp) {
-    const { isAuthenticated } = useConnectAuth()
+    const { isAuthenticated, getToken } = useConnectAuth()
     const store = useConnectAccountStore()
 
     if (isAuthenticated.value) {
-      // initialize user accounts and user profile on app mount
+      // Initialize user accounts and user profile on app mount
       await Promise.all([
         store.initAccountStore(),
         store.syncUserProfile()
       ])
+
+      // Force token refresh to return updated roles
+      // Required only for new users
+      if (store.userAccounts.length > 0) {
+        await getToken(true)
+      }
     }
 
     // sync user profile whenever the token is updated

--- a/packages/layers/auth/tests/unit/plugins/connect-account-bootstrap.test.ts
+++ b/packages/layers/auth/tests/unit/plugins/connect-account-bootstrap.test.ts
@@ -7,11 +7,17 @@ import plugin from '../../../app/plugins/connect-account-bootstrap.client'
 const runPlugin = (app: unknown) => plugin.setup!(app as any)
 
 const mockIsAuthenticated = ref(false)
+const mockGetToken = vi.fn()
 mockNuxtImport('useConnectAuth', () => () => ({
-  isAuthenticated: mockIsAuthenticated
+  isAuthenticated: mockIsAuthenticated,
+  getToken: mockGetToken
 }))
 
+const mockUserAccounts = ref<any[]>([])
 const mockStore = {
+  get userAccounts() {
+    return mockUserAccounts.value
+  },
   initAccountStore: vi.fn(),
   syncUserProfile: vi.fn(),
   switchCurrentAccount: vi.fn()
@@ -32,6 +38,7 @@ describe('Connect Account Bootstrap Plugin', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockIsAuthenticated.value = false
+    mockUserAccounts.value = []
     middlewareCallback = null
 
     mockNuxtApp = {
@@ -71,6 +78,32 @@ describe('Connect Account Bootstrap Plugin', () => {
 
       expect(mockStore.initAccountStore).toHaveBeenCalledOnce()
       expect(mockStore.syncUserProfile).toHaveBeenCalledOnce()
+    })
+
+    it('should force token refresh if authenticated user has 0 accounts', async () => {
+      mockIsAuthenticated.value = true
+      mockUserAccounts.value = []
+
+      mockStore.initAccountStore.mockResolvedValue(undefined)
+      mockStore.syncUserProfile.mockResolvedValue(undefined)
+      mockGetToken.mockResolvedValue(undefined)
+
+      await runPlugin(mockNuxtApp)
+
+      expect(mockGetToken).toHaveBeenCalledWith(true)
+      expect(mockGetToken).toHaveBeenCalledOnce()
+    })
+
+    it('should NOT force token refresh if authenticated user has 1 or more accounts', async () => {
+      mockIsAuthenticated.value = true
+      mockUserAccounts.value = [{ id: 1234, name: 'Existing Account' }]
+
+      mockStore.initAccountStore.mockResolvedValue(undefined)
+      mockStore.syncUserProfile.mockResolvedValue(undefined)
+
+      await runPlugin(mockNuxtApp)
+
+      expect(mockGetToken).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#33691

*Description of changes:*
- force token refresh for new user AFTER user is created in auth db, required to return updated roles for subsequent requests

*Screenshots (if applicable):*

---

<details>
<summary><b>⚠️ First time contributing to bcgov/connect-nuxt? Click here!</b></summary>

#### Contributor Checklist

- **Onboarding**
  - [ ] I have read the project's main **README**.
  - [ ] I have read and agree to the **Code of Conduct**.
  - [ ] I have read the **CONTRIBUTING guide** for development standards and workflow.
- **Code & Context**
  - [ ] I have read the **package-specific README** for the package I am modifying.
  - [ ] **Code Style:** My code follows the project's established style guidelines.
  - [ ] **i18n:** All text is managed via language files; no hardcoded strings.
  - [ ] **Responsive:** I have verified this change works on multiple screen sizes.
  - [ ] **Testing:** I have added or updated unit or E2E tests to cover my changes.
  - [ ] **Local Build:** I have successfully built the project locally and confirmed no new errors.
  - [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).
- **Documentation & Examples**
  - [ ] I have updated the relevant documentation (or created new documentation).
  - [ ] I have updated the relevant examples (or created new examples) in the `.playground` directory for new components, composables, pages, etc.
</details>

---

#### ⚠️ Reviewer Checklist
*This section is to be completed by the reviewer.*

- [ ] **Requirements:** Code matches the issue requirements.
- [ ] **Security:** No secrets/keys committed.
- [ ] **Standards:** Follows the code style and standards defined in the CONTRIBUTING file.
- [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BSD-3-Clause license.