### PR TITLE
33708 - Create account page: Add optional body text and hide back button if user has 0 accounts

### DIFF
--- a/.changeset/pink-laws-fail.md
+++ b/.changeset/pink-laws-fail.md
@@ -1,0 +1,5 @@
+---
+"@sbc-connect/nuxt-auth": patch
+---
+
+Create account page: Add optional body text and hide back button if user has 0 accounts

--- a/packages/layers/auth/.playground/i18n/locales/en-CA.ts
+++ b/packages/layers/auth/.playground/i18n/locales/en-CA.ts
@@ -1,0 +1,11 @@
+/* eslint-disable max-len */
+export default {
+  /* Ordering should be alphabetical unless otherwise specified */
+  connect: {
+    page: {
+      createAccount: {
+        description: ['PLAYGROUND ONLY - Create a new account to use your services and manage all of your businesses within BC Registries.']
+      }
+    }
+  }
+}

--- a/packages/layers/auth/.playground/i18n/locales/fr-CA.ts
+++ b/packages/layers/auth/.playground/i18n/locales/fr-CA.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/packages/layers/auth/.playground/nuxt.config.ts
+++ b/packages/layers/auth/.playground/nuxt.config.ts
@@ -1,4 +1,22 @@
 export default defineNuxtConfig({
   extends: ['..'],
-  modules: []
+  modules: [],
+  i18n: {
+    locales: [
+      {
+        name: 'English',
+        code: 'en-CA',
+        language: 'en-CA',
+        dir: 'ltr',
+        file: 'en-CA.ts'
+      },
+      {
+        name: 'Français',
+        code: 'fr-CA',
+        language: 'fr-CA',
+        dir: 'ltr',
+        file: 'fr-CA.ts'
+      }
+    ]
+  }
 })

--- a/packages/layers/auth/app/pages/auth/account/select.vue
+++ b/packages/layers/auth/app/pages/auth/account/select.vue
@@ -25,6 +25,12 @@ const pageTitle = computed(() =>
     ? $t('connect.label.existingAccountFound')
     : $t('connect.label.sbcAccountCreation')
 )
+const createAccountDesc = computed(() => {
+  const desc = useNuxtApp().$i18n.tm('connect.page.createAccount.description')
+  return Array.isArray(desc) && (desc as Array<unknown>).length > 0
+    ? desc
+    : []
+})
 
 useHead({
   title: pageTitle
@@ -69,9 +75,14 @@ onBeforeMount(() => {
 <template>
   <UContainer class="max-w-6xl">
     <ConnectTransitionFade>
-      <div class="space-y-6 sm:space-y-10">
+      <div class="space-y-4 sm:space-y-6">
         <h1>{{ pageTitle }}</h1>
         <ConnectAccountExistingAlert v-if="showAccountList" />
+        <div v-else-if="!showAccountList && createAccountDesc.length" class="space-y-2">
+          <p v-for="text in createAccountDesc" :key="text">
+            {{ $rt(text) }}
+          </p>
+        </div>
       </div>
     </ConnectTransitionFade>
 
@@ -124,6 +135,7 @@ onBeforeMount(() => {
       data-testid="create-account-button-wrapper"
     >
       <UButton
+        v-if="store.userAccounts.length > 0"
         variant="outline"
         :label="$t('connect.label.back')"
         :disabled="isSubmitting"

--- a/packages/layers/auth/i18n/locales/en-CA.ts
+++ b/packages/layers/auth/i18n/locales/en-CA.ts
@@ -62,7 +62,8 @@ export default {
         phonePlaceholder: 'Enter phone number',
         phoneExtensionLabel: 'Phone extension (Optional)',
         addressLabel: 'Address',
-        countryLabel: 'Country'
+        countryLabel: 'Country',
+        description: []
       }
     },
     sessionExpiry: {


### PR DESCRIPTION
*Issue #:* bcgov/entity#33708

*Description of changes:*
- create account page:
  - Add optional body text
  - hide back button if user has 0 accounts

*Screenshots (if applicable):*

---

<details>
<summary><b>⚠️ First time contributing to bcgov/connect-nuxt? Click here!</b></summary>

#### Contributor Checklist

- **Onboarding**
  - [ ] I have read the project's main **README**.
  - [ ] I have read and agree to the **Code of Conduct**.
  - [ ] I have read the **CONTRIBUTING guide** for development standards and workflow.
- **Code & Context**
  - [ ] I have read the **package-specific README** for the package I am modifying.
  - [ ] **Code Style:** My code follows the project's established style guidelines.
  - [ ] **i18n:** All text is managed via language files; no hardcoded strings.
  - [ ] **Responsive:** I have verified this change works on multiple screen sizes.
  - [ ] **Testing:** I have added or updated unit or E2E tests to cover my changes.
  - [ ] **Local Build:** I have successfully built the project locally and confirmed no new errors.
  - [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).
- **Documentation & Examples**
  - [ ] I have updated the relevant documentation (or created new documentation).
  - [ ] I have updated the relevant examples (or created new examples) in the `.playground` directory for new components, composables, pages, etc.
</details>

---

#### ⚠️ Reviewer Checklist
*This section is to be completed by the reviewer.*

- [ ] **Requirements:** Code matches the issue requirements.
- [ ] **Security:** No secrets/keys committed.
- [ ] **Standards:** Follows the code style and standards defined in the CONTRIBUTING file.
- [ ] **Accessibility:** Verified WCAG compliance (ARIA labels, keyboard navigation, and focus management).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the BSD-3-Clause license.