### PR TITLE
chore: upgrade packageManager to pnpm@11.9.0

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
 
       - name: Setup node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/layers-auth-ci.yml
+++ b/.github/workflows/layers-auth-ci.yml
@@ -27,7 +27,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:
@@ -60,7 +59,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/layers-base-ci.yml
+++ b/.github/workflows/layers-base-ci.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:
@@ -59,7 +58,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/layers-forms-ci.yml
+++ b/.github/workflows/layers-forms-ci.yml
@@ -27,7 +27,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:
@@ -60,7 +59,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/layers-pay-ci.yml
+++ b/.github/workflows/layers-pay-ci.yml
@@ -28,7 +28,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:
@@ -61,7 +60,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: false
     - uses: actions/setup-node@v4
       with:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -61,7 +61,6 @@ jobs:
       if: steps.package_list.outputs.list != ''
       uses: pnpm/action-setup@v4
       with:
-        version: 10
 
     - name: Setup node.js
       if: steps.package_list.outputs.list != ''

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: latest-11
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -9,6 +9,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
+  workflow_dispatch:
 
 jobs:
   test-pnpm-v11:

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,41 @@
+name: Test pnpm v11 upgrade
+on:
+  push:
+    branches: [feat/upgrade-pnpm-v11]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/test-pnpm-v11.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        layer: [auth, base, forms, pay]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies (whole workspace)
+        run: pnpm install
+
+      - name: Build ${{ matrix.layer }}
+        working-directory: packages/layers/${{ matrix.layer }}
+        run: pnpm build
+
+      - name: Report pnpm version
+        run: pnpm --version

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
       "@vue/runtime-dom": "3.5.39",
       "@vue/reactivity": "3.5.39"
     }
-  }
+  },
+  "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,14 +14,14 @@ minimumReleaseAge: 4320 # 3 days
 autoInstallPeers: true
 shamefullyHoist: true
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - unrs-resolver
-  - vue-demi
-
 overrides:
   vue: 3.5.39
   '@vue/runtime-core': 3.5.39
   '@vue/runtime-dom': 3.5.39
   '@vue/reactivity': 3.5.39
+
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  unrs-resolver: true
+  vue-demi: true


### PR DESCRIPTION
## Summary
- Adds `packageManager: pnpm@11.9.0` to the root `package.json` (this repo had no packageManager field set previously).
- Converts `pnpm-workspace.yaml`'s `onlyBuiltDependencies` (a pnpm v10 setting no longer read in v11) to the new `allowBuilds` map syntax, for `@parcel/watcher`, `esbuild`, `unrs-resolver`, and `vue-demi`.
- Removes the hardcoded `pnpm/action-setup` version input (`10`) from all 6 workflow files (`changesets.yml`, 4x `layers-*-ci.yml`, `pkg-pr-new.yml`) — this now conflicts with `packageManager` and hard-errors ("Multiple versions of pnpm specified"); the action auto-detects the version from `packageManager` instead.

Part of ticket #33875 (pnpm v11 upgrade).

## Test plan
- [x] Full workspace `pnpm install` locally with pnpm 11.9.0 — clean, no `ERR_PNPM_IGNORED_BUILDS`
- [x] `pnpm typecheck` (runs across all 4 layers: auth, base, forms, pay) — passes
- [ ] CI green